### PR TITLE
Fix comment processing

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -11,7 +11,7 @@ import (
 func Root() *cobra.Command {
 	p := &rootParams{}
 	cmd := &cobra.Command{
-		Use:           "yam",
+		Use:           "yam <file>...",
 		Short:         "format YAML files",
 		SilenceErrors: true,
 		SilenceUsage:  true,

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -17,8 +17,10 @@ func Root() *cobra.Command {
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options := yam.FormatOptions{
-				Indent:         p.indentSize,
-				GapExpressions: p.gaps,
+				Indent:                 p.indentSize,
+				GapExpressions:         p.gaps,
+				TrimTrailingWhitespace: true,
+				FinalNewline:           true,
 			}
 
 			if p.lint {

--- a/pkg/rwfs/tester/tester.go
+++ b/pkg/rwfs/tester/tester.go
@@ -68,7 +68,10 @@ func (fsys *FS) Truncate(string, int64) error {
 
 func (fsys *FS) Diff(name string) string {
 	if tf, ok := fsys.fixtures[name]; ok {
-		diff := cmp.Diff(tf.expectedRead.String(), tf.writtenBack.String())
+		want := tf.expectedRead.Bytes()
+		got := tf.writtenBack.Bytes()
+
+		diff := cmp.Diff(want, got)
 
 		if diff == "" {
 			return ""

--- a/pkg/yam/apply.go
+++ b/pkg/yam/apply.go
@@ -1,0 +1,78 @@
+package yam
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/chainguard-dev/yam/pkg/yam/formatted"
+	"gopkg.in/yaml.v3"
+)
+
+func apply(input io.Reader, options FormatOptions) (*bytes.Buffer, error) {
+	b, err := io.ReadAll(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if options.TrimTrailingWhitespace {
+		b = trimTrailingWhitespace(b)
+	}
+
+	if options.FinalNewline {
+		b = ensureFinalNewline(b)
+	}
+
+	root := &yaml.Node{}
+	decoder := yaml.NewDecoder(bytes.NewReader(b))
+	err = decoder.Decode(root)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	enc := formatted.NewEncoder(buf)
+	enc.SetIndent(options.Indent)
+	err = enc.SetGapExpressions(options.GapExpressions...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to set gap expression for encoder: %w", err)
+	}
+
+	err = enc.Encode(root)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
+func trimTrailingWhitespace(in []byte) []byte {
+	var out []byte
+
+	scanner := bufio.NewScanner(bytes.NewReader(in))
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		trimmedLine := bytes.TrimRight(line, " \t")
+		out = append(out, trimmedLine...)
+
+		// Add back the newline, which is stripped during scanning.
+		out = append(out, []byte("\n")...)
+	}
+
+	return out
+}
+
+func ensureFinalNewline(in []byte) []byte {
+	var newline = []byte("\n")
+
+	if len(in) == 0 {
+		return newline
+	}
+
+	if in[len(in)-1] == newline[0] {
+		return in
+	}
+
+	return append(in, newline...)
+}

--- a/pkg/yam/format_test.go
+++ b/pkg/yam/format_test.go
@@ -18,6 +18,9 @@ func Test_formatPath(t *testing.T) {
 		{
 			fixture: "testdata/format/acl.yaml",
 		},
+		{
+			fixture: "testdata/format/comments.yaml",
+		},
 	}
 
 	options := FormatOptions{

--- a/pkg/yam/format_test.go
+++ b/pkg/yam/format_test.go
@@ -21,6 +21,9 @@ func Test_formatPath(t *testing.T) {
 		{
 			fixture: "testdata/format/comments.yaml",
 		},
+		{
+			fixture: "testdata/format/whitespace_issues.yaml",
+		},
 	}
 
 	options := FormatOptions{
@@ -28,6 +31,8 @@ func Test_formatPath(t *testing.T) {
 		GapExpressions: []string{
 			".",
 		},
+		TrimTrailingWhitespace: true,
+		FinalNewline:           true,
 	}
 
 	for _, tt := range cases {

--- a/pkg/yam/formatted/encoder.go
+++ b/pkg/yam/formatted/encoder.go
@@ -177,7 +177,7 @@ func (enc *Encoder) marshalSequence(node *yaml.Node, nodePath path.Path) ([]byte
 		// For scalar items, pull out the head comment, so we can control its encoding
 		// here, rather than delegate it to the underlying encoder.
 		var extractedHeadComment string
-		if item.Kind == yaml.ScalarNode && item.HeadComment != "" {
+		if item.HeadComment != "" {
 			extractedHeadComment = item.HeadComment + "\n"
 			item.HeadComment = ""
 		}
@@ -199,6 +199,7 @@ func (enc *Encoder) marshalSequence(node *yaml.Node, nodePath path.Path) ([]byte
 
 			// Precede with a dash.
 			itemBytes = bytes.Join([][]byte{
+				[]byte(extractedHeadComment),
 				dashSpace,
 				itemBytes,
 			}, nil)

--- a/pkg/yam/formatted/encoder.go
+++ b/pkg/yam/formatted/encoder.go
@@ -174,19 +174,35 @@ func (enc *Encoder) marshalSequence(node *yaml.Node, nodePath path.Path) ([]byte
 	var lines [][]byte
 
 	for i, item := range node.Content {
+		// For scalar items, pull out the head comment, so we can control its encoding
+		// here, rather than delegate it to the underlying encoder.
+		var extractedHeadComment string
+		if item.Kind == yaml.ScalarNode && item.HeadComment != "" {
+			extractedHeadComment = item.HeadComment + "\n"
+			item.HeadComment = ""
+		}
+
 		itemBytes, err := enc.marshal(item, nodePath.AppendSeqPart(i))
 		if err != nil {
 			return nil, err
 		}
 
-		if item.Kind != yaml.ScalarNode {
+		if item.Kind == yaml.ScalarNode {
+			// Print head comment first. Then continue.
+			itemBytes = bytes.Join([][]byte{
+				[]byte(extractedHeadComment),
+				dashSpace,
+				itemBytes,
+			}, nil)
+		} else {
 			itemBytes = enc.applyIndentExceptFirstLine(itemBytes)
-		}
 
-		itemBytes = bytes.Join([][]byte{
-			dashSpace,
-			itemBytes,
-		}, nil)
+			// Precede with a dash.
+			itemBytes = bytes.Join([][]byte{
+				dashSpace,
+				itemBytes,
+			}, nil)
+		}
 
 		lines = append(lines, itemBytes)
 	}

--- a/pkg/yam/testdata/format/comments.yaml
+++ b/pkg/yam/testdata/format/comments.yaml
@@ -1,0 +1,22 @@
+# This is a comment that spans
+# multiple lines.
+a:
+  # initial comment
+  - 1
+  - 2
+
+  # And finally
+  - 3
+  # Trailing comment.
+
+  - "And here's a string!"
+  - |
+    And a multi-line
+    string, too!
+
+
+
+b:
+  # comment before a mapping
+  - this: is cool
+    and: this is also cool

--- a/pkg/yam/testdata/format/comments_expected.yaml
+++ b/pkg/yam/testdata/format/comments_expected.yaml
@@ -1,0 +1,18 @@
+# This is a comment that spans
+# multiple lines.
+a:
+  # initial comment
+  - 1
+  - 2
+  # And finally
+  - 3
+  # Trailing comment.
+  - "And here's a string!"
+  - |
+      And a multi-line
+      string, too!
+
+b:
+  # comment before a mapping
+  - this: is cool
+    and: this is also cool

--- a/pkg/yam/testdata/format/simple.yaml
+++ b/pkg/yam/testdata/format/simple.yaml
@@ -4,6 +4,7 @@ age: 80
 
 things:
   - fork
+
   - knife
 
   - spoon

--- a/pkg/yam/testdata/format/whitespace_issues.yaml
+++ b/pkg/yam/testdata/format/whitespace_issues.yaml
@@ -1,0 +1,11 @@
+# Be careful not to reformat or trim whitespace on this file.
+# It has intentional stray and missing whitespaces for testing.
+fruits:
+  - apple 
+  - banana
+  
+  - orange
+  - multiline: |
+      fruits 
+      taste
+      good

--- a/pkg/yam/testdata/format/whitespace_issues_expected.yaml
+++ b/pkg/yam/testdata/format/whitespace_issues_expected.yaml
@@ -1,0 +1,10 @@
+# Be careful not to reformat or trim whitespace on this file.
+# It has intentional stray and missing whitespaces for testing.
+fruits:
+  - apple
+  - banana
+  - orange
+  - multiline: |
+      fruits
+      taste
+      good


### PR DESCRIPTION
This addresses a few cases where unexpected formatting would happen, either because of the upstream library (https://github.com/go-yaml/yaml) or because of yam itself.

1. Comments being lost
2. Comments in lists resulting in malformation

This also makes a change such that, before formatting is applied, all files undergo two "cleaning steps" that are common reasons for surprise structural encodings from https://github.com/go-yaml/yaml.

1. All lines have any trailing spaces trimmed
2. Ensures all files end with a final newline character