### PR TITLE
Support configuration via config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ yam a.yaml --lint
 
 ## Formatting/Linting Options
 
+### Gap Lines
+
 To expect a gap (empty line) in between child elements of a given node, just pass a `yq`-style path to the node, using `--gap`. You can use this flag as many times as needed.
 
 ```shell
@@ -46,4 +48,84 @@ yam a.yaml --gap '.recipes[0].ingredients'
 
 ```shell
 yam a.yaml --gap '.types.*.inputs'
+```
+
+### Indentation
+
+You can also set the indent size (number of spaces) using `--indent`. Yam uses 2-space indentation by default.
+
+```shell
+yam a.yaml --indent 4
+```
+
+### Using a config file
+
+Yam will also look for a `.yam.yaml` file in the current working directory as a source of configuration. Using a config file is optional. CLI flag values take priority over config file values. The config file can be used to configure `indent` and `gap` values only.
+
+Example `.yam.yaml`:
+
+```yaml
+indent: 4   # Defaults to 2
+
+gap:        # Defaults to none
+- "."
+- ".users"
+```
+
+## Yam's Encoder
+
+Yam has a special YAML encoder it uses to handle formatting as it writes out YAML bytes. This encoder is configurable.
+
+Yam bases its encoder on the YAML encoder from https://github.com/go-yaml/yaml, and uses this library's `yaml.Node` type as the input to encoding operations.
+
+This means you're able to decode data using https://github.com/go-yaml/yaml, modify data as needed, and then encode the `yaml.Node` using **yam's encoder** instead. This is nifty if you want to write YAML data that's correctly formatted from the beginning.
+
+For example, before:
+
+```go
+import (
+    // ...
+    "gopkg.in/yaml.v3"
+)
+
+func someFunction(myData yaml.Node, w io.Writer) {
+    enc := yaml.NewEncoder(w)
+
+    // use the encoder!
+	_ = enc.Encode(myData)
+}
+```
+
+And after:
+
+```go
+import (
+    // ...
+    "github.com/chainguard-dev/yam/pkg/yam/formatted"
+)
+
+func someFunction(myData yaml.Node, w io.Writer) {
+    enc := formatted.NewEncoder(w)
+
+    // use the encoder!
+    _ = enc.Encode(myData)
+}
+```
+
+### Configuring the encoder
+
+Yam's encoder has chainable methods that can be used for configuring its options.
+
+For example:
+
+```go
+enc := formatted.NewEncoder(w).SetIndent(2).SetGapExpressions(".", ".users")
+```
+
+#### Configuring the encoder with `.yam.yaml`
+
+You can also tell the encoder to behave similarly to the `yam` command, in that a `.yam.yaml` is automatically read if available.
+
+```go
+enc := formatted.NewEncoder(w).AutomaticConfig()
 ```

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/kr/pretty v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -7,8 +8,17 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
@@ -21,8 +31,10 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,62 +1,110 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 
 	osAdapter "github.com/chainguard-dev/yam/pkg/rwfs/os"
 	"github.com/chainguard-dev/yam/pkg/yam"
+	"github.com/chainguard-dev/yam/pkg/yam/formatted"
 	"github.com/spf13/cobra"
 )
 
+const (
+	flagIndent       = "indent"
+	flagGap          = "gap"
+	flagFinalNewline = "final-newline"
+	flagTrimLines    = "trim-lines"
+	flagLint         = "lint"
+)
+
 func Root() *cobra.Command {
-	p := &rootParams{}
 	cmd := &cobra.Command{
 		Use:           "yam <file>...",
 		Short:         "format YAML files",
 		SilenceErrors: true,
 		SilenceUsage:  true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			options := yam.FormatOptions{
-				Indent:                 p.indentSize,
-				GapExpressions:         p.gaps,
-				TrimTrailingWhitespace: true,
-				FinalNewline:           true,
-			}
-
-			if p.lint {
-				fsys := os.DirFS(".")
-
-				err := yam.Lint(fsys, args, yam.ExecDiff, options)
-				if err != nil {
-					return err
-				}
-
-				return nil
-			}
-
-			fsys := osAdapter.DirFS(".")
-			err := yam.Format(fsys, args, options)
-			if err != nil {
-				return err
-			}
-
-			return nil
-		},
 	}
 
-	p.addToCmd(cmd)
+	cmd.Flags().Int(flagIndent, 2, "number of spaces used to indent a line")
+	cmd.Flags().StringSlice(flagGap, nil, "YAML path expression to a mapping or sequence node whose children should be separated by empty lines")
+	cmd.Flags().Bool(flagFinalNewline, true, "ensure file ends with a final newline character")
+	cmd.Flags().Bool(flagTrimLines, true, "trim any trailing spaces from each line")
+	cmd.Flags().Bool(flagLint, false, "don't modify files, but exit 1 if files aren't formatted")
+
+	cmd.RunE = runRoot
 
 	return cmd
 }
 
-type rootParams struct {
-	lint       bool
-	indentSize int
-	gaps       []string
+func runRoot(cmd *cobra.Command, args []string) error {
+	var err error
+
+	encoderConfig, err := formatted.ReadConfig()
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	formatOptions := computeFormatOptions(encoderConfig, cmd)
+	doLint, _ := cmd.Flags().GetBool(flagLint)
+
+	if doLint {
+		fsys := os.DirFS(".")
+
+		err = yam.Lint(fsys, args, yam.ExecDiff, formatOptions)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	fsys := osAdapter.DirFS(".")
+	err = yam.Format(fsys, args, formatOptions)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func (p *rootParams) addToCmd(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&p.lint, "lint", false, "don't modify files, but exit 1 if files aren't formatted")
-	cmd.Flags().IntVar(&p.indentSize, "indent", 2, "number of spaces used to indent a line")
-	cmd.Flags().StringSliceVar(&p.gaps, "gap", nil, "YAML path expression to a mapping or sequence node whose children should be separated by empty lines")
+// computeFormatOptions produces a new yam.FormatOptions using an optional
+// provided config (unmarshalled from a file) and flags from a Cobra command.
+// CLI flag values take priority over config file values, which take priority
+// over default values.
+func computeFormatOptions(cfg *formatted.EncodeOptions, cmd *cobra.Command) yam.FormatOptions {
+	flags := cmd.Flags()
+
+	var indent = 2
+	if flag := flags.Lookup(flagIndent); flag.Changed {
+		indent, _ = flags.GetInt(flagIndent)
+	} else if cfg != nil {
+		indent = cfg.Indent
+	}
+
+	var gapExpressions []string
+	if flag := flags.Lookup(flagGap); flag.Changed {
+		gapExpressions, _ = flags.GetStringSlice(flagGap)
+	} else if cfg != nil {
+		gapExpressions = cfg.GapExpressions
+	}
+
+	var finalNewline = true
+	if flag := flags.Lookup(flagFinalNewline); flag.Changed {
+		finalNewline, _ = flags.GetBool(flagFinalNewline)
+	}
+
+	var trimLines = true
+	if flag := flags.Lookup(flagTrimLines); flag.Changed {
+		trimLines, _ = flags.GetBool(flagTrimLines)
+	}
+
+	return yam.FormatOptions{
+		EncodeOptions: formatted.EncodeOptions{
+			Indent:         indent,
+			GapExpressions: gapExpressions,
+		},
+		FinalNewline:           finalNewline,
+		TrimTrailingWhitespace: trimLines,
+	}
 }

--- a/pkg/yam/apply.go
+++ b/pkg/yam/apply.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func apply(input io.Reader, options FormatOptions) (*bytes.Buffer, error) {
+func applyFormatting(input io.Reader, options FormatOptions) (*bytes.Buffer, error) {
 	b, err := io.ReadAll(input)
 	if err != nil {
 		return nil, err
@@ -33,10 +33,9 @@ func apply(input io.Reader, options FormatOptions) (*bytes.Buffer, error) {
 
 	buf := new(bytes.Buffer)
 	enc := formatted.NewEncoder(buf)
-	enc.SetIndent(options.Indent)
-	err = enc.SetGapExpressions(options.GapExpressions...)
+	enc, err = enc.UseOptions(options.EncodeOptions)
 	if err != nil {
-		return nil, fmt.Errorf("unable to set gap expression for encoder: %w", err)
+		return nil, fmt.Errorf("unable to use options with encoder: %w", err)
 	}
 
 	err = enc.Encode(root)

--- a/pkg/yam/format.go
+++ b/pkg/yam/format.go
@@ -6,23 +6,6 @@ import (
 	"github.com/chainguard-dev/yam/pkg/rwfs"
 )
 
-type FormatOptions struct {
-	// Indent specifies how many spaces to use per-indentation
-	Indent int
-
-	// GapExpressions specifies a list of yq-style paths for which the path's YAML
-	// element's children elements should be separated by an empty line
-	GapExpressions []string
-
-	// FinalNewline specifies whether to ensure the input has a final newline before
-	// further formatting is applied.
-	FinalNewline bool
-
-	// TrimTrailingWhitespace specifies whether to trim any trailing space
-	// characters from each line before further formatting is applied.
-	TrimTrailingWhitespace bool
-}
-
 func Format(fsys rwfs.FS, paths []string, options FormatOptions) error {
 	for _, path := range paths {
 		err := formatPath(fsys, path, options)
@@ -44,7 +27,7 @@ func formatPath(fsys rwfs.FS, path string, options FormatOptions) error {
 
 	defer file.Close()
 
-	formatted, err := apply(file, options)
+	formatted, err := applyFormatting(file, options)
 	if err != nil {
 		return err
 	}

--- a/pkg/yam/format_test.go
+++ b/pkg/yam/format_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/chainguard-dev/yam/pkg/rwfs/tester"
+	"github.com/chainguard-dev/yam/pkg/yam/formatted"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,9 +28,11 @@ func Test_formatPath(t *testing.T) {
 	}
 
 	options := FormatOptions{
-		Indent: 2,
-		GapExpressions: []string{
-			".",
+		EncodeOptions: formatted.EncodeOptions{
+			Indent: 2,
+			GapExpressions: []string{
+				".",
+			},
 		},
 		TrimTrailingWhitespace: true,
 		FinalNewline:           true,

--- a/pkg/yam/lint.go
+++ b/pkg/yam/lint.go
@@ -33,7 +33,7 @@ func lintPath(fsys fs.FS, path string, handler DiffHandler, options FormatOption
 
 	defer file.Close()
 
-	formatted, err := apply(tee, options)
+	formatted, err := applyFormatting(tee, options)
 	if err != nil {
 		return err
 	}

--- a/pkg/yam/options.go
+++ b/pkg/yam/options.go
@@ -1,0 +1,16 @@
+package yam
+
+import "github.com/chainguard-dev/yam/pkg/yam/formatted"
+
+type FormatOptions struct {
+	// EncodeOptions specifies the encoder-specific format options.
+	EncodeOptions formatted.EncodeOptions
+
+	// FinalNewline specifies whether to ensure the input has a final newline before
+	// further formatting is applied.
+	FinalNewline bool `mapstructure:"final-newline"`
+
+	// TrimTrailingWhitespace specifies whether to trim any trailing space
+	// characters from each line before further formatting is applied.
+	TrimTrailingWhitespace bool `mapstructure:"trim-lines"`
+}


### PR DESCRIPTION
This PR adds more documentation to the README about how to configure `yam`.

It also adds support for configuring yam's formatting via a ` .yam.yaml` file in the current working directory, which lets you define the expected formatting behavior centrally and avoid the need for CLI flags on each execution.

The `.yam.yaml` file can be leveraged by both the `yam` command and yam's exported `Encoder`.