### PR TITLE
Remove color flag since it fails on busybox

### DIFF
--- a/pkg/yam/diff.go
+++ b/pkg/yam/diff.go
@@ -44,7 +44,6 @@ func ExecDiff(want, got []byte) error {
 		command,
 		"-U",
 		"5",
-		"--color=always",
 		"--label",
 		"want",
 		"--label",


### PR DESCRIPTION
Failing with a red herring error [here](https://github.com/wolfi-dev/os/actions/runs/4954326516/jobs/8862722136?pr=1985#step:5:8)

Looks like busybox's `diff` does not have `--color` so it fails whenever `yam` tries to spit out a diff.