### PR TITLE
handle formatting of empty but not nil structs

### DIFF
--- a/pkg/yam/format_test.go
+++ b/pkg/yam/format_test.go
@@ -36,6 +36,9 @@ func Test_formatSingleFile(t *testing.T) {
 		{
 			fixture: "testdata/format/whitespace_issues.yaml",
 		},
+		{
+			fixture: "testdata/format/update.yaml",
+		},
 	}
 
 	for _, tt := range cases {

--- a/pkg/yam/testdata/format/update.yaml
+++ b/pkg/yam/testdata/format/update.yaml
@@ -1,0 +1,6 @@
+update:
+  enabled: true
+  git: {}
+  schedule:
+    daily: true
+    reason: upstream does not maintain tags or releases, it uses a branch

--- a/pkg/yam/testdata/format/update_expected.yaml
+++ b/pkg/yam/testdata/format/update_expected.yaml
@@ -1,0 +1,6 @@
+update:
+  enabled: true
+  git: {}
+  schedule:
+    daily: true
+    reason: upstream does not maintain tags or releases, it uses a branch


### PR DESCRIPTION
Initially this is a test case to demonstrate what I'm hoping for.  The test will fail, not 100% sure where to fix, maybe in `encoder.go`?  I tried adding the below to the `marshalMapping` function but we get an extra indented line so figure there's more to it.  


```
	if len(node.Content) == 0 {
		// This is an empty mapping node, we should return "{}"
		return []byte("{}\n"), nil
	}
```

Here's an example of what happens without this support https://github.com/rawlingsj/wolfi-os/pull/2064/files#diff-c1e7e6d93bdcfdbf44020ead40b6f83e46b82b28422c8a70fd48accc5e6acdd0L44