### PR TITLE
handle formatting of empty but not nil structs (continued)

### DIFF
--- a/pkg/yam/format_test.go
+++ b/pkg/yam/format_test.go
@@ -36,6 +36,9 @@ func Test_formatSingleFile(t *testing.T) {
 		{
 			fixture: "testdata/format/whitespace_issues.yaml",
 		},
+		{
+			fixture: "testdata/format/update.yaml",
+		},
 	}
 
 	for _, tt := range cases {

--- a/pkg/yam/testdata/format/update.yaml
+++ b/pkg/yam/testdata/format/update.yaml
@@ -1,0 +1,6 @@
+update:
+  enabled: true
+  git: {}
+  schedule:
+    daily: true
+    reason: upstream does not maintain tags or releases, it uses a branch

--- a/pkg/yam/testdata/format/update_expected.yaml
+++ b/pkg/yam/testdata/format/update_expected.yaml
@@ -1,0 +1,6 @@
+update:
+  enabled: true
+  git: {}
+  schedule:
+    daily: true
+    reason: upstream does not maintain tags or releases, it uses a branch


### PR DESCRIPTION
A continuation of #65  — had trouble pushing to @rawlingsj's branch

This is an experimental workaround for handling of empty flow style mappings, i.e. `{}`