### PR TITLE
feat: ability to specify path to config file

### DIFF
--- a/pkg/yam/formatted/encoder.go
+++ b/pkg/yam/formatted/encoder.go
@@ -104,7 +104,7 @@ func ReadConfigFrom(r io.Reader) (*EncodeOptions, error) {
 
 	err := yaml.NewDecoder(r).Decode(&options)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read yam config: %w", err)
+		return nil, fmt.Errorf("parsing yam config: %w", err)
 	}
 
 	return &options, nil


### PR DESCRIPTION
By default, `yam` looks for a config file in the current directory named `.yam.yaml`.

This PR adds a **new flag** `-c`/`--config` that lets the user provide a path to a yam configuration YAML file more explicitly. If no value is provided, `yam` falls back to its default mechanism for finding a config.