### PR TITLE
Add pre-commit-hook support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: yam
+    name: Format yaml properly using yam
+    description: Helps to prevent any linting check failures in CI 
+    entry: yam
+    language: go
+    stages: [pre-commit, manual]
+    types: [yaml]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,6 @@
     name: Format yaml properly using yam
     description: Helps to prevent any linting check failures in CI 
     entry: yam
-    language: go
+    language: golang
     stages: [pre-commit, manual]
     types: [yaml]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,4 @@
     entry: yam
     language: golang
     stages: [pre-commit, manual]
-    types: [yaml]
+    types: [yml]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,4 @@
     entry: yam
     language: golang
     stages: [pre-commit, manual]
-    types: [yml]
+    types: ["yaml"]


### PR DESCRIPTION
To enable https://github.com/chainguard-dev/internal-dev/issues/9314, we need a `.pre-commit-hooks.yaml` file to tell pre-commit how to build and run the tool. 