### PR TITLE
Go Upgrade / golangci-lint / ci clean up

### DIFF
--- a/.github/chainguard/release.sts.yaml
+++ b/.github/chainguard/release.sts.yaml
@@ -1,0 +1,11 @@
+# Copyright 2025 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/yam:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: chainguard-dev/yam/.github/workflows/release.yaml@refs/heads/main
+
+# the release workflow needs write permissions to create and push tags
+permissions:
+  contents: write

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,13 +8,24 @@ on:
     branches:
       - "main"
 
-jobs:
+permissions: {}
 
+jobs:
   build-test:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           check-latest: true
           cache: true
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,29 @@ on:
   schedule:
     - cron: '0 0 * * 1' # weekly on Monday at 00:00
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "dry-run mode: if true, no git tags will be pushed."
+        type: boolean
+        default: false
+      release_type:
+        description: "Type of Release"
+        required: true
+        default: build
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+          - prerelease
+          - build
+      forced_version:
+        description: "(Optional) SemVer2-compliant forced-version to tag explicitly, instead of auto-bumping.
+                      Must not already exist"
+        required: false
+        type: string
+
+permissions: {}
 
 jobs:
   release:
@@ -11,23 +34,46 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read # to read the repo and tags
+      id-token: write # to inject the OIDC token to octo-sts
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        with:
+          scope: ${{ github.repository }}
+          identity: release
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0 # fetch all history for all tags and branches
+          token: ${{ steps.octo-sts.outputs.token }}
+
       - name: Check if any changes since last tag
         id: check
         run: |
           git fetch --tags
           if [ -z "$(git tag --points-at HEAD)" ]; then
             echo "Nothing points at HEAD, bump a new tag"
-            echo "bump=yes" >> $GITHUB_OUTPUT
+            echo "bump=yes" >> "$GITHUB_OUTPUT"
           else
             echo "A tag already points to head, don't bump"
-            echo "bump=no" >> $GITHUB_OUTPUT
+            echo "bump=no" >> "$GITHUB_OUTPUT"
           fi
-      - name: Bump patch version and push tag
-        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
+
+      - name: Bump and push Git tag
+        uses: chainguard-dev/actions/git-tag@93d7e48486a0ec24d253345d8b5378a5551b7be9 # v1.0.4
         if: steps.check.outputs.bump == 'yes'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.octo-sts.outputs.token }}
+          git_tag_prefix: "v"
+          bump_level: ${{ inputs.release_type || 'patch' }}
+          dry_run: ${{ inputs.dry_run || 'false'}}
+          forced_version: ${{ inputs.forced_version || '' }}
+          author: "octo-sts[bot] <157150467+octo-sts[bot]@users.noreply.github.com>"
+          committer: "octo-sts[bot] <157150467+octo-sts[bot]@users.noreply.github.com>"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,8 +15,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           check-latest: true
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,24 +1,37 @@
 name: Verify
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - "main"
   pull_request:
 
+permissions: {}
+
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: '1.24'
           check-latest: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.61
+          version: v2.1

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,19 +6,7 @@ issues:
 formatters:
   enable:
     - goimports # checks if the code and import statements are formatted according to the 'goimports' command
-    - golines # checks if code is formatted, and fixes long lines
-
-    ## you may want to enable
-    #- gci # checks if code and import statements are formatted, with additional rules
-    #- gofmt # checks if the code is formatted according to 'gofmt' command
-
-    ## disabled
-    #- gofumpt # [replaced by goimports, gofumports is not available yet] checks if code and import statements are formatted, with additional rules
-
-  # All settings can be found here https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml
-  settings:
-    golines:
-      max-len: 120
+    - gofmt # checks if the code is formatted according to 'gofmt' command
 
 linters:
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,259 @@
+version: "2"
+
+issues:
+  max-same-issues: 50
+
+formatters:
+  enable:
+    - goimports # checks if the code and import statements are formatted according to the 'goimports' command
+    - golines # checks if code is formatted, and fixes long lines
+
+    ## you may want to enable
+    #- gci # checks if code and import statements are formatted, with additional rules
+    #- gofmt # checks if the code is formatted according to 'gofmt' command
+
+    ## disabled
+    #- gofumpt # [replaced by goimports, gofumports is not available yet] checks if code and import statements are formatted, with additional rules
+
+  # All settings can be found here https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml
+  settings:
+    golines:
+      max-len: 120
+
+linters:
+  enable:
+    - asasalint # checks for pass []any as any in variadic func(...any)
+    - asciicheck # checks that your code does not contain non-ASCII identifiers
+    - bidichk # checks for dangerous unicode character sequences
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - canonicalheader # checks whether net/http.Header uses canonical header
+    - copyloopvar # detects places where loop variables are copied (Go 1.22+)
+    - cyclop # checks function and package cyclomatic complexity
+    - dupl # tool for code clone detection
+    - durationcheck # checks for two durations multiplied together
+    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
+    - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
+    - exptostd # detects functions from golang.org/x/exp/ that can be replaced by std functions
+    - fatcontext # detects nested contexts in loops
+    - forbidigo # forbids identifiers
+    - funcorder # checks the order of functions, methods, and constructors
+    - funlen # tool for detection of long functions
+    - gocheckcompilerdirectives # validates go compiler directive comments (//go:)
+    - gochecknoinits # checks that no init functions are present in Go code
+    - gochecksumtype # checks exhaustiveness on Go "sum types"
+    - goconst # finds repeated strings that could be replaced by a constant
+    - gocritic # provides diagnostics that check for bugs, performance and style issues
+    - gocyclo # computes and checks the cyclomatic complexity of functions
+    - godot # checks if comments end in a period
+    - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
+    - goprintffuncname # checks that printf-like functions are named with f at the end
+    - gosec # inspects source code for security problems
+    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - iface # checks the incorrect use of interfaces, helping developers avoid interface pollution
+    - ineffassign # detects when assignments to existing variables are not used
+    - intrange # finds places where for loops could make use of an integer range
+    - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
+    - makezero # finds slice declarations with non-zero initial length
+    - mirror # reports wrong mirror patterns of bytes/strings usage
+    - musttag # enforces field tags in (un)marshaled structs
+    - nakedret # finds naked returns in functions greater than a specified function length
+    - noctx # finds sending http request without context.Context
+    - nolintlint # reports ill-formed or insufficient nolint directives
+    - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
+    - perfsprint # checks that fmt.Sprintf can be replaced with a faster alternative
+    - predeclared # finds code that shadows one of Go's predeclared identifiers
+    - promlinter # checks Prometheus metrics naming via promlint
+    - protogetter # reports direct reads from proto message fields when getters should be used
+    - reassign # checks that package variables are not reassigned
+    - recvcheck # checks for receiver type consistency
+    - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
+    - rowserrcheck # checks whether Err of rows is checked successfully
+    - sloglint # ensure consistent code style when using log/slog
+    - spancheck # checks for mistakes with OpenTelemetry/Census spans
+    - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
+    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
+    - testableexamples # checks if examples are testable (have an expected output)
+    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
+    - unconvert # removes unnecessary type conversions
+    - unparam # reports unused function parameters
+    - unused # checks for unused constants, variables, functions and types
+    - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
+    - usetesting # reports uses of functions with replacement inside the testing package
+    - wastedassign # finds wasted assignment statements
+    - whitespace # detects leading and trailing whitespace
+
+  settings:
+    cyclop:
+      max-complexity: 30
+      package-average: 10.0
+
+    errcheck:
+      check-type-assertions: true
+
+    exhaustive:
+      check:
+        - switch
+        - map
+
+    funcorder:
+      # Checks if the exported methods of a structure are placed before the non-exported ones.
+      # Default: true
+      struct-method: false
+
+    funlen:
+      # Checks the number of lines in a function.
+      # If lower than 0, disable the check.
+      # Default: 60
+      lines: 100
+      # Checks the number of statements in a function.
+      # If lower than 0, disable the check.
+      # Default: 40
+      statements: 50
+
+    gochecksumtype:
+      # Presence of `default` case in switch statements satisfies exhaustiveness, if all members are not listed.
+      # Default: true
+      default-signifies-exhaustive: false
+
+    gocritic:
+      # Settings passed to gocritic.
+      # The settings key is the name of a supported gocritic checker.
+      # The list of supported checkers can be found at https://go-critic.com/overview.
+      settings:
+        captLocal:
+          # Whether to restrict checker to params only.
+          # Default: true
+          paramsOnly: false
+        underef:
+          # Whether to skip (*x).method() calls where x is a pointer receiver.
+          # Default: true
+          skipRecvDeref: false
+
+    govet:
+      # Enable all analyzers.
+      # Default: false
+      enable-all: true
+      # Disable analyzers by name.
+      # Run `GL_DEBUG=govet golangci-lint run --enable=govet` to see default, all available analyzers, and enabled analyzers.
+      # Default: []
+      disable:
+        - fieldalignment # too strict
+      # Settings per analyzer.
+      settings:
+        shadow:
+          # Whether to be strict about shadowing; can be noisy.
+          # Default: false
+          strict: true
+
+    gosec:
+      excludes:
+        - G204
+        - G304
+
+    inamedparam:
+      # Skips check for interface methods with only a single parameter.
+      # Default: false
+      skip-single-param: true
+
+    nakedret:
+      # Make an issue if func has more lines of code than this setting, and it has naked returns.
+      # Default: 30
+      max-func-lines: 0
+
+    nolintlint:
+      # Exclude following linters from requiring an explanation.
+      # Default: []
+      allow-no-explanation: [ funlen, golines ]
+      # Enable to require an explanation of nonzero length after each nolint directive.
+      # Default: false
+      require-explanation: true
+      # Enable to require nolint directives to mention the specific linter being suppressed.
+      # Default: false
+      require-specific: true
+
+    perfsprint:
+      # Optimizes into strings concatenation.
+      # Default: true
+      strconcat: false
+
+    reassign:
+      # Patterns for global variable names that are checked for reassignment.
+      # See https://github.com/curioswitch/go-reassign#usage
+      # Default: ["EOF", "Err.*"]
+      patterns:
+        - ".*"
+
+    rowserrcheck:
+      # database/sql is always checked.
+      # Default: []
+      packages:
+        - github.com/jmoiron/sqlx
+
+    sloglint:
+      # Enforce not using global loggers.
+      # Values:
+      # - "": disabled
+      # - "all": report all global loggers
+      # - "default": report only the default slog logger
+      # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-global
+      # Default: ""
+      no-global: all
+      # Enforce using methods that accept a context.
+      # Values:
+      # - "": disabled
+      # - "all": report all contextless calls
+      # - "scope": report only if a context exists in the scope of the outermost function
+      # https://github.com/go-simpler/sloglint?tab=readme-ov-file#context-only
+      # Default: ""
+      context: scope
+
+    staticcheck:
+      # SAxxxx checks in https://staticcheck.dev/docs/configuration/options/#checks
+      # Example (to disable some checks): [ "all", "-SA1000", "-SA1001"]
+      # Default: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+      checks:
+        - all
+        # Incorrect or missing package comment.
+        # https://staticcheck.dev/docs/checks/#ST1000
+        - -ST1000
+        # Use consistent method receiver names.
+        # https://staticcheck.dev/docs/checks/#ST1016
+        - -ST1016
+        # Omit embedded fields from selector expression.
+        # https://staticcheck.dev/docs/checks/#QF1008
+        - -QF1008
+
+    usetesting:
+      os-temp-dir: true
+
+  exclusions:
+    # Log a warning if an exclusion rule is unused.
+    # Default: false
+    warn-unused: true
+    presets:
+      - std-error-handling
+      - common-false-positives
+    # Excluding configuration per-path, per-linter, per-text and per-source.
+    rules:
+      - source: 'TODO'
+        linters: [ godot ]
+      - text: 'should have a package comment'
+        linters: [ revive ]
+      - text: 'exported \S+ \S+ should have comment( \(or a comment on this block\))? or be unexported'
+        linters: [ revive ]
+      - text: 'package comment should be of the form ".+"'
+        source: '// ?(nolint|TODO)'
+        linters: [ revive ]
+      - text: 'comment on exported \S+ \S+ should be of the form ".+"'
+        source: '// ?(nolint|TODO)'
+        linters: [ revive, staticcheck ]
+      - path: '_test\.go'
+        linters:
+          - bodyclose
+          - dupl
+          - errcheck
+          - funlen
+          - goconst
+          - gosec
+          - noctx
+          - wrapcheck

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainguard-dev/yam
 
-go 1.23
+go 1.24
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/pkg/yam/format.go
+++ b/pkg/yam/format.go
@@ -22,9 +22,9 @@ func Format(fsys rwfs.FS, paths []string, options FormatOptions) error {
 		}
 
 		if stat.IsDir() {
-			err := formatDir(fsys, p, options)
-			if err != nil {
-				return fmt.Errorf("unable to format directory %q: %w", p, err)
+			errDir := formatDir(fsys, p, options)
+			if errDir != nil {
+				return fmt.Errorf("unable to format directory %q: %w", p, errDir)
 			}
 
 			continue
@@ -51,9 +51,9 @@ func formatDir(fsys rwfs.FS, dirPath string, options FormatOptions) error {
 		}
 
 		p := filepath.Join(dirPath, file.Name())
-		err := formatSingleFile(fsys, p, options)
-		if err != nil {
-			return err
+		errsingleFile := formatSingleFile(fsys, p, options)
+		if errsingleFile != nil {
+			return errsingleFile
 		}
 	}
 
@@ -93,7 +93,7 @@ func formatSingleFile(fsys rwfs.FS, path string, options FormatOptions) error {
 		return err
 	}
 
-	writeableFile.Close()
+	_ = writeableFile.Close()
 
 	return nil
 }

--- a/pkg/yam/formatted/encoder.go
+++ b/pkg/yam/formatted/encoder.go
@@ -258,7 +258,6 @@ func (enc Encoder) marshal(node *yaml.Node, nodePath path.Path) ([]byte, error) 
 
 	default:
 		return yaml.Marshal(node)
-
 	}
 }
 

--- a/pkg/yam/formatted/encoder_test.go
+++ b/pkg/yam/formatted/encoder_test.go
@@ -2,7 +2,6 @@ package formatted
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/chainguard-dev/yam/pkg/yam/formatted/path"
@@ -19,8 +18,7 @@ const (
 
 func TestEncoder_AutomaticConfig(t *testing.T) {
 	t.Run("gracefully handles missing config file", func(t *testing.T) {
-		err := os.Chdir("testdata/empty-dir")
-		require.NoError(t, err)
+		t.Chdir("testdata/empty-dir")
 
 		w := new(bytes.Buffer)
 

--- a/pkg/yam/formatted/path/path.go
+++ b/pkg/yam/formatted/path/path.go
@@ -175,13 +175,12 @@ func partsMatch(pattern, testSubject Part) bool {
 		return true
 
 	case mapPart:
-		ts := testSubject.(mapPart)
+		ts, _ := testSubject.(mapPart)
 		return tp.key == ts.key || tp.key == anyKey
 
 	case seqPart:
-		ts := testSubject.(seqPart)
+		ts, _ := testSubject.(seqPart)
 		return tp.index == ts.index || tp.index == anyIndex
-
 	}
 
 	return false

--- a/pkg/yam/formatted/path/path_test.go
+++ b/pkg/yam/formatted/path/path_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var assertErrExpressionNotSupported assert.ErrorAssertionFunc = func(t assert.TestingT, err error, i ...interface{}) bool {
+var assertErrExpressionNotSupported assert.ErrorAssertionFunc = func(t assert.TestingT, err error, _ ...interface{}) bool {
 	return assert.ErrorIs(t, err, ErrExpressionNotSupported)
 }
 

--- a/pkg/yam/lint.go
+++ b/pkg/yam/lint.go
@@ -32,16 +32,16 @@ func Lint(fsys fs.FS, paths []string, handler DiffHandler, options FormatOptions
 		}
 
 		if stat.IsDir() {
-			err := lintDir(fsys, p, handler, options)
-			if err != nil {
+			errLint := lintDir(fsys, p, handler, options)
+			if errLint != nil {
 				var e errLintCheckFailed
-				if errors.As(err, &e) {
+				if errors.As(errLint, &e) {
 					pathsThatFailedLinting = append(pathsThatFailedLinting, e.paths...)
 					continue
 				}
 
 				// An error more serious than lint check failure has occurred.
-				return err
+				return errLint
 			}
 
 			continue
@@ -80,14 +80,14 @@ func lintDir(fsys fs.FS, dirPath string, handler DiffHandler, options FormatOpti
 		}
 
 		p := filepath.Join(dirPath, file.Name())
-		err := lintSingleFile(fsys, p, handler, options)
-		if err != nil {
-			if errors.As(err, &errLintCheckFailed{}) {
+		errSingleFile := lintSingleFile(fsys, p, handler, options)
+		if errSingleFile != nil {
+			if errors.As(errSingleFile, &errLintCheckFailed{}) {
 				dirEntriesThatFailedLinting = append(dirEntriesThatFailedLinting, p)
 				continue
 			}
 
-			return err
+			return errSingleFile
 		}
 	}
 
@@ -128,9 +128,9 @@ func lintSingleFile(fsys fs.FS, path string, handler DiffHandler, options Format
 		fmt.Fprintf(os.Stderr, "%s has a diff from the expected formatting\n", path)
 
 		if handler != nil {
-			err := handler(want, got)
-			if err != nil {
-				return fmt.Errorf("unable to handle diff: %w", err)
+			errHandler := handler(want, got)
+			if errHandler != nil {
+				return fmt.Errorf("unable to handle diff: %w", errHandler)
 			}
 		}
 

--- a/pkg/yam/lint_test.go
+++ b/pkg/yam/lint_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func didNotPassLintCheck(t assert.TestingT, err error, i ...interface{}) bool {
+func didNotPassLintCheck(t assert.TestingT, err error, _ ...interface{}) bool {
 	return assert.ErrorIs(t, err, ErrDidNotPassLintCheck)
 }
 


### PR DESCRIPTION
- upgrade to go 1.24
- apply ci best practices and add golangci-lint config
- refactor release to use cg/actions and octo-sts
- fix lints


the release job is following the same approach we now have in the chainguard-dev/action and other repos