### PR TITLE
Fix: preserve newlines for folded style (>) YAML blocks

### DIFF
--- a/pkg/yam/formatted/encoder.go
+++ b/pkg/yam/formatted/encoder.go
@@ -254,6 +254,26 @@ func (enc Encoder) marshal(node *yaml.Node, nodePath path.Path) ([]byte, error) 
 		if enc.matchesAnyQuotePath(nodePath) {
 			node.Style |= yaml.DoubleQuotedStyle
 		}
+
+		// Fix: For FoldedStyle (>) blocks, preserve newlines instead of joining lines
+		if node.Style == yaml.FoldedStyle {
+			// Manually encode folded style
+			var buf bytes.Buffer
+			buf.WriteString(">\n")
+			lines := strings.Split(node.Value, "\n")
+			for i, line := range lines {
+				if i > 0 {
+					buf.WriteString("\n")
+				}
+				if line != "" {
+					buf.WriteString(enc.indentString())
+				}
+				buf.WriteString(line)
+			}
+			buf.WriteString("\n")
+			return buf.Bytes(), nil
+		}
+
 		return yaml.Marshal(node)
 
 	default:


### PR DESCRIPTION
This PR ensures that yam preserves newlines for folded style (>) YAML blocks, rather than joining lines into a single line. This resolves issue #112 and brings yam’s output in line with YAML spec and user expectations.