### PR TITLE
fix: add bounds checking in marshalMapping to prevent index out of range panic

### DIFF
--- a/pkg/yam/formatted/encoder.go
+++ b/pkg/yam/formatted/encoder.go
@@ -309,10 +309,16 @@ func (enc Encoder) marshalMapping(node *yaml.Node, nodePath path.Path) ([]byte, 
 				colon,
 			}, nil)
 
-			if nextItem := node.Content[i+1]; (nextItem.Kind == yaml.ScalarNode && nextItem.Tag != "!!null") || nextItem.Style == yaml.FlowStyle { // TODO: check that there is a value node for this key node
-				// render in same line
-				keyBytes = append(keyBytes, space...)
+			if i+1 < len(node.Content) {
+				// Check that there is a value node for this key node before accessing it
+				if nextItem := node.Content[i+1]; (nextItem.Kind == yaml.ScalarNode && nextItem.Tag != "!!null") || nextItem.Style == yaml.FlowStyle {
+					// render in same line
+					keyBytes = append(keyBytes, space...)
+				} else {
+					keyBytes = append(keyBytes, newline...)
+				}
 			} else {
+				// No corresponding value for this key, add newline
 				keyBytes = append(keyBytes, newline...)
 			}
 

--- a/pkg/yam/formatted/encoder_test.go
+++ b/pkg/yam/formatted/encoder_test.go
@@ -329,6 +329,44 @@ func TestDedupWithNonScalarNodes(t *testing.T) {
 	}
 }
 
+func TestMarshalMappingWithMissingValue(t *testing.T) {
+	// Test that the encoder doesn't crash when a mapping has a key without a corresponding value
+	// This tests the bounds checking fix for accessing node.Content[i+1]
+	
+	// Create a malformed mapping node with odd number of content items (key without value)
+	keyNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: "key",
+	}
+	
+	mappingNode := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{keyNode}, // Only key, no value - this would cause index out of bounds
+	}
+	
+	var out bytes.Buffer
+	encoder := NewEncoder(&out)
+	encoder = encoder.SetIndent(2)
+	
+	nodePath, err := path.Parse(".")
+	if err != nil {
+		t.Fatalf("failed to parse path: %+v", err)
+	}
+	
+	// This should not panic and should handle the missing value gracefully
+	result, err := encoder.marshalMapping(mappingNode, nodePath)
+	if err != nil {
+		t.Errorf("marshalMapping failed: %+v", err)
+	}
+	
+	// The result should contain the key with a newline (since no value exists)
+	expected := "key:\n"
+	if string(result) != expected {
+		t.Errorf("unexpected result: got %q, want %q", string(result), expected)
+	}
+}
+
 func checkDiff(t *testing.T, expected, actual any) {
 	t.Helper()
 


### PR DESCRIPTION
<img width="1681" height="735" alt="Screenshot from 2025-07-23 18-28-31" src="https://github.com/user-attachments/assets/f845ce4b-b1e2-49d3-887b-611daf5e2846" />

The marshalMapping function was accessing node.Content[i+1] without verifying that i+1 was within bounds, causing "index out of range [3] with length 3" panics when processing YAML mappings with odd numbers of content items (keys without corresponding values).

This fix adds proper bounds checking before accessing the next item and handles the case where a key has no corresponding value by adding a newline.

The TODO comment requesting this bounds check has been updated to reflect that the check is now implemented.

Fixes crashes in CVE automation pipeline tests and other scenarios where malformed YAML mappings are processed.

🤖 Generated with [Claude Code](https://claude.ai/code)