### PR TITLE
fix: emit lint diff in conventional got→want direction

### DIFF
--- a/pkg/yam/diff.go
+++ b/pkg/yam/diff.go
@@ -40,16 +40,21 @@ func ExecDiff(want, got []byte) error {
 		return fmt.Errorf("unable to execute diff command: %w", err)
 	}
 
+	// Diff from "got" (the current file contents) to "want" (the correctly
+	// formatted output) so the printed diff reads in the conventional
+	// direction: removed lines are what's there now, added lines are the fix.
+	// This matches tools like `gofmt -d`, `prettier` and `black --diff`, and
+	// means the output can be applied as a patch to format the file.
 	cmd := exec.Command(
 		command,
 		"-U",
 		"5",
 		"--label",
-		"want",
-		"--label",
 		"got",
-		tempWant.Name(),
+		"--label",
+		"want",
 		tempGot.Name(),
+		tempWant.Name(),
 	)
 	cmd.Stdout = handlerOutput
 	cmd.Stderr = handlerOutput


### PR DESCRIPTION
ExecDiff ran `diff want got` with labels `--- want` / `+++ got`, so the printed diff described how to turn the correctly-formatted file into the current (unformatted) one. That is the inverse of the convention used by `gofmt -d`, `prettier` and `black --diff`, where the diff goes from the current file to the expected output and can be applied directly as a patch to fix formatting.

Swap the operands and labels so the output is `--- got` / `+++ want`: removed lines are the current contents, added lines are the fix.

No behavioral change to formatting or lint pass/fail; only the direction and labels of the informational diff. lint_test.go asserts on the returned error only, so existing tests are unaffected.