### PR TITLE
fix(ci): GitHub Actions security hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,7 @@ jobs:
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           fetch-depth: 0 # fetch all history for all tags and branches
           token: ${{ steps.octo-sts.outputs.token }}
 

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,10 @@
+rules:
+  # Paired with `cooldown.default-days: 3` in .github/dependabot.yml.
+  dependabot-cooldown:
+    config:
+      days: 3
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
Automated GitHub Actions security hardening (zizmor + actionlint + shellcheck,
plus manual review). Workflow-config only — no application code is touched.

## Changes

- **Scope down checkout credentials** — `persist-credentials: false` on the
  `release.yaml` checkout. The only git write (the `git-tag` action) receives
  its token explicitly and the changes-check step is read-only, so the checkout
  token needn't be left in `.git/config`.

- **Add a zizmor config + dependabot cooldown** — a `.github/zizmor.yml`
  disabling a few cosmetic pedantic rules (`anonymous-definition`,
  `concurrency-limits`), plus a 3-day cooldown on each dependabot ecosystem so
  brand-new (and potentially compromised) dependency releases aren't pulled the
  instant they ship.

Refs: PSEC-923